### PR TITLE
Set query to yield instead of print responses.

### DIFF
--- a/ksql/api.py
+++ b/ksql/api.py
@@ -49,7 +49,7 @@ class BaseAPI(object):
             raise ValueError('Status Code: {}.\nMessage: {}'.format(r.status_code, r.content))
 
     def query(self, query_string, encoding='utf-8', chunk_size=128):
-        """  
+        """
         Process streaming incoming data.
 
         """
@@ -57,7 +57,7 @@ class BaseAPI(object):
 
         for chunk in r.iter_content(chunk_size=chunk_size):
             if chunk != b'\n':
-                print(chunk.decode(encoding))
+                yield chunk.decode(encoding)
 
     def _request(self, endpoint, method='post', sql_string=''):
         url = '{}/{}'.format(self.url, endpoint)


### PR DESCRIPTION
Thoughts?  Can't do much with the response if it's being printed to stdout.  Will follow up with unit tests if this is generally agreeable.