### PR TITLE
Fix unit test failure on python 3.4.4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 nose
-vcrpy
 codecov
+vcrpy==1.13.0
 coverage
 confluent-kafka[avro]


### PR DESCRIPTION
The vcrpy dependency have been updated to V2.0.0
This causes the ksql-python unit tests to fail when using python 3.4.4.

The vcrpy depenency have now been fixed to use vcrpy V1.13.0.