### PR TITLE
Unit test vcrpy dependency changed to latest version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 nose
 codecov
-vcrpy==1.13.0
+vcrpy
 coverage
 confluent-kafka[avro]


### PR DESCRIPTION
The vcrpy dependency bug with python 3.4 have been fixed in the latest
version: vcrpy-2.0.1 (https://github.com/kevin1024/vcrpy/pull/395). Reverted back to using the latest VCR version for unit tests.