### PR TITLE
manifest file was missing requirements files 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt test-requirements.txt


### PR DESCRIPTION
manifest file was missing requirements files  which made the sdist package uninstallable