### PR TITLE
Add support for Basic Authentication on KSQL API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,13 @@ Setup for ksql-python API
     logging.basicConfig(level=logging.DEBUG)
     client = KSQLAPI('http://ksql-server:8088')
 
+- Setup for KSQL API with Basic Authentication
+
+.. code:: python
+
+    from ksql import KSQLAPI
+    client = KSQLAPI('http://ksql-server:8088', api_key="your_key", secret="your_secret")
+
 Options
 ~~~~~~~
 
@@ -68,6 +75,10 @@ Options
 | ``url``       | string    | yes        | Your ksql-server url. Example: ``http://ksql-server:8080``   |
 +---------------+-----------+------------+--------------------------------------------------------------+
 | ``timeout``   | integer   | no         | Timout for Requests. Default: ``5``                          |
++---------------+-----------+------------+--------------------------------------------------------------+
+| ``api_key``   | string    | no         | API Key to use on the requests                               |
++---------------+-----------+------------+--------------------------------------------------------------+
+| ``secret``    | string    | no         | Secret to use on the requests                                |
 +---------------+-----------+------------+--------------------------------------------------------------+
 
 Main Methods

--- a/ksql/api.py
+++ b/ksql/api.py
@@ -1,6 +1,5 @@
 import functools
 import json
-import threading
 import time
 import logging
 
@@ -17,6 +16,8 @@ class BaseAPI(object):
         self.max_retries = kwargs.get("max_retries", 3)
         self.delay = kwargs.get("delay", 0)
         self.timeout = kwargs.get("timeout", 15)
+        self.api_key = kwargs.get("api_key")
+        self.secret = kwargs.get("secret")
 
     def get_timout(self):
         return self.timeout
@@ -79,6 +80,9 @@ class BaseAPI(object):
                     print('Ending query because of time out! ({} seconds)'.format(idle_timeout))
                     return
 
+    def get_request(self, endpoint):
+        return requests.get(endpoint, auth=(self.api_key, self.secret))
+
     def _request(self, endpoint, method='post', sql_string='', stream_properties=None):
         url = '{}/{}'.format(self.url, endpoint)
 
@@ -108,7 +112,8 @@ class BaseAPI(object):
             data=data,
             timeout=self.timeout,
             headers=headers,
-            stream=stream)
+            stream=stream,
+            auth=(self.api_key, self.secret))
 
         return r
 

--- a/ksql/client.py
+++ b/ksql/client.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import requests
-
 from ksql.api import SimplifiedAPI
 
 
@@ -10,6 +8,10 @@ class KSQLAPI(object):
     """ API Class """
 
     def __init__(self, url, max_retries=3, check_version=True, **kwargs):
+        """
+        You can use a Basic Authentication with this API, for now we accept the api_key/secret based on the Confluent
+        Cloud implementation. So you just need to put on the kwargs the api_key and secret.
+        """
         self.url = url
         self.sa = SimplifiedAPI(url, max_retries=max_retries, **kwargs)
         if check_version is True:
@@ -23,7 +25,7 @@ class KSQLAPI(object):
         return self.sa.get_timout()
 
     def get_ksql_version(self):
-        r = requests.get(self.url + "/info")
+        r = self.sa.get_request(self.url + "/info")
         if r.status_code == 200:
             info = r.json().get('KsqlServerInfo')
             version = info.get('version')


### PR DESCRIPTION
This PR adds support for Basic Authentication on KSQL API based on how Confluent Cloud exposes the KSQL service. This was needed to let the user uses this wrapper with Confluent Cloud.

This should solve #61 issue or at least open the path to a solution.