### PR TITLE
Support new query-stream API with HTTP/2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ This command returns a generator. It can be printed e.g. by reading its values v
 
 Query with HTTP/2
 ^^^^^^^^^^^^^^^^^
-Execute queries with the new ``query-stream`` endpoint. Documented `here <https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/streaming-endpoint/#executing-pull-or-push-queries>`_
+Execute queries with the new ``/query-stream`` endpoint. Documented `here <https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/streaming-endpoint/#executing-pull-or-push-queries>`_
 
 To execute a sql query use the same syntax as the regular query, with the additional ``use_http2=True`` parameter.
 
@@ -142,6 +142,29 @@ A generator is returned with the following example response
        [3,43.0,"Palo Alto"]
        [3,43.0,"Palo Alto"]
        [3,43.0,"Palo Alto"]
+
+To terminate the query above use the ``close_query`` call.
+Provide the ``queryId`` returned from the ``query`` call.
+
+.. code:: python
+
+    client.close_query("44d8413c-0018-423d-b58f-3f2064b9a312")
+
+Insert rows into a Stream with HTTP/2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Uses the new ``/inserts-stream`` endpoint. See `documentation <https://docs.ksqldb.io/en/0.10.0-ksqldb/developer-guide/ksqldb-rest-api/streaming-endpoint/#inserting-rows-into-an-existing-stream>`_
+
+.. code:: python
+
+    rows = [
+            {"ORDER_ID": 1, "TOTAL_AMOUNT": 23.5, "CUSTOMER_NAME": "abc"},
+            {"ORDER_ID": 2, "TOTAL_AMOUNT": 3.7, "CUSTOMER_NAME": "xyz"}
+        ]
+
+    results = self.api_client.inserts_stream("my_stream_name", rows)
+
+An array of object will be returned on success, with the status of each row inserted.
 
 
 Simplified API

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,26 @@ This command returns a generator. It can be printed e.g. by reading its values v
        {"row":{"columns":[1512787753488,"key1",1,2,3]},"errorMessage":null}
        {"row":{"columns":[1512787753888,"key1",1,2,3]},"errorMessage":null}
 
+Query with HTTP/2
+^^^^^^^^^^^^^^^^^
+Execute queries with the new ``query-stream`` endpoint. Documented `here <https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/streaming-endpoint/#executing-pull-or-push-queries>`_
+
+To execute a sql query use the same syntax as the regular query, with the additional ``use_http2=True`` parameter.
+
+.. code:: python
+
+    client.query('select * from table1', use_http2=True)
+
+A generator is returned with the following example response
+
+   ::
+
+       {"queryId":"44d8413c-0018-423d-b58f-3f2064b9a312","columnNames":["ORDER_ID","TOTAL_AMOUNT","CUSTOMER_NAME"],"columnTypes":["INTEGER","DOUBLE","STRING"]}
+       [3,43.0,"Palo Alto"]
+       [3,43.0,"Palo Alto"]
+       [3,43.0,"Palo Alto"]
+
+
 Simplified API
 ~~~~~~~~~~~~~~
 

--- a/ksql/api.py
+++ b/ksql/api.py
@@ -197,7 +197,7 @@ class BaseAPI(object):
             raise ValueError("Return code is {}.".format(response.status_code))
 
     def inserts_stream(self, stream_name, rows):
-        body = f'{{"target":"{stream_name}"}}'
+        body = '{{"target":"{}"}}'.format(stream_name)
         for row in rows:
             body += '\n{}'.format(json.dumps(row))
 

--- a/ksql/api.py
+++ b/ksql/api.py
@@ -79,7 +79,7 @@ class BaseAPI(object):
         start_idle = None
 
         if streaming_response.status == 200:
-            for chunk in streaming_response:
+            for chunk in streaming_response.read_chunked():
                 if chunk != b"\n":
                     start_idle = None
                     yield chunk.decode(encoding)

--- a/ksql/client.py
+++ b/ksql/client.py
@@ -62,6 +62,9 @@ class KSQLAPI(object):
     def close_query(self, query_id):
         return self.sa.close_query(query_id)
 
+    def inserts_stream(self, stream_name, rows):
+        return self.sa.inserts_stream(stream_name, rows)
+
     def create_stream(self, table_name, columns_type, topic, value_format="JSON"):
         return self.sa.create_stream(
             table_name=table_name, columns_type=columns_type, topic=topic, value_format=value_format

--- a/ksql/client.py
+++ b/ksql/client.py
@@ -42,7 +42,7 @@ class KSQLAPI(object):
         return self.sa.ksql(ksql_string, stream_properties=stream_properties)
 
     def query(self, query_string, encoding="utf-8", chunk_size=128, stream_properties=None, idle_timeout=None):
-        return self.sa.query(
+        return self.sa.query2(
             query_string=query_string,
             encoding=encoding,
             chunk_size=chunk_size,

--- a/ksql/client.py
+++ b/ksql/client.py
@@ -59,6 +59,9 @@ class KSQLAPI(object):
                 idle_timeout=idle_timeout,
             )
 
+    def close_query(self, query_id):
+        return self.sa.close_query(query_id)
+
     def create_stream(self, table_name, columns_type, topic, value_format="JSON"):
         return self.sa.create_stream(
             table_name=table_name, columns_type=columns_type, topic=topic, value_format=value_format

--- a/ksql/client.py
+++ b/ksql/client.py
@@ -41,14 +41,23 @@ class KSQLAPI(object):
     def ksql(self, ksql_string, stream_properties=None):
         return self.sa.ksql(ksql_string, stream_properties=stream_properties)
 
-    def query(self, query_string, encoding="utf-8", chunk_size=128, stream_properties=None, idle_timeout=None):
-        return self.sa.query2(
-            query_string=query_string,
-            encoding=encoding,
-            chunk_size=chunk_size,
-            stream_properties=stream_properties,
-            idle_timeout=idle_timeout,
-        )
+    def query(self, query_string, encoding="utf-8", chunk_size=128, stream_properties=None, idle_timeout=None, use_http2=None):
+        if use_http2:
+            return self.sa.query2(
+                query_string=query_string,
+                encoding=encoding,
+                chunk_size=chunk_size,
+                stream_properties=stream_properties,
+                idle_timeout=idle_timeout,
+            )
+        else:
+            return self.sa.query(
+                query_string=query_string,
+                encoding=encoding,
+                chunk_size=chunk_size,
+                stream_properties=stream_properties,
+                idle_timeout=idle_timeout,
+            )
 
     def create_stream(self, table_name, columns_type, topic, value_format="JSON"):
         return self.sa.create_stream(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,3 +45,4 @@ wcwidth==0.2.5
 wrapt==1.12.1
 yarl==1.4.2
 zipp==3.1.0
+hyper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 six
 urllib3
+hyper

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools_kwargs = {
     'install_requires': [
 	    'requests',
 		'six',
-		'urllib3'
+		'urllib3',
+        'hyper'
     ],
     'zip_safe': False,
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,6 +133,14 @@ class TestKSQLAPI(unittest.TestCase):
             self.assertEqual(chunk_obj, [3,43.0, "Palo Alto"])
             break
 
+    @unittest.skipIf(not utils.check_kafka_available("localhost:29092"), "vcrpy does not support streams yet")
+    def test_ksql_close_query(self):
+        result = self.api_client.close_query("123")
+
+        self.assertFalse(result)
+
+
+
     @vcr.use_cassette("tests/vcr_cassettes/bad_requests.yml")
     def test_bad_requests(self):
         broken_ksql_string = "noi"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -108,8 +108,11 @@ class TestKSQLAPI(unittest.TestCase):
             "select * from {} EMIT CHANGES".format(stream_name), stream_properties=streamProperties
         )
 
+        header = next(chunks)
+        self.assertEqual(header, """[{"header":{"queryId":"none","schema":"`ORDER_ID` INTEGER, `TOTAL_AMOUNT` DOUBLE, `CUSTOMER_NAME` STRING"}},\n""")
+
         for chunk in chunks:
-            self.assertTrue(chunk)
+            self.assertEqual(chunk, """{"row":{"columns":[3,43.0,"Palo Alto"]}},\n""")
             break
 
     @vcr.use_cassette("tests/vcr_cassettes/bad_requests.yml")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,12 +133,13 @@ class TestKSQLAPI(unittest.TestCase):
             self.assertEqual(chunk_obj, [3,43.0, "Palo Alto"])
             break
 
-    @vcr.use_cassette("tests/vcr_cassettes/ksql_close_query.yml")
+    @unittest.skipIf(not utils.check_kafka_available("localhost:29092"), "vcrpy does not support HTTP/2")
     def test_ksql_close_query(self):
         result = self.api_client.close_query("123")
 
         self.assertFalse(result)
 
+    @unittest.skipIf(not utils.check_kafka_available("localhost:29092"), "vcrpy does not support streams yet")
     def test_inserts_stream(self):
         topic = self.exist_topic
         stream_name = "TEST_INSERTS_STREAM_STREAM"


### PR DESCRIPTION
Added optional support for the new HTTP/2 endpoint for queries, requested in https://github.com/bryanyang0528/ksql-python/issues/77

This is a non breaking change. The new endpoint will only be used when `use_http2=True` is passed into `Query` in the client.

Since it looks like Python's `requests` does not support HTTP/2, added the [Hyper](https://hyper.readthedocs.io/) package.

The test for Query was enhanced to test both HTTP/1.1 and HTTP/2 with the `/query` and `/query-stream` endpoints receptively 