### PR TITLE
fixed exception handling of ksql

### DIFF
--- a/ksql/api.py
+++ b/ksql/api.py
@@ -122,7 +122,7 @@ class BaseAPI(object):
                 raise http_error
             else:
                 logging.debug("content: {}".format(content))
-                raise KSQLError(e=content.get("message"), error_code=content.get("error_code"))
+                raise KSQLError(content.get("message"), content.get("error_code"), content.get("stackTrace"))
         else:
             return r
 


### PR DESCRIPTION
Hi team,

I am using ksql 0.10.1.1 version and it doesn't throw any error if I execute a wrong command. 
But for the same code with previous ksql version 0.5.1.1 it shows the error.

My Code:
![image](https://user-images.githubusercontent.com/22065325/91004969-5be98400-e5f5-11ea-9cc3-4741e22fb3d5.png)

Error from ksql: 0.5.1.1
![image](https://user-images.githubusercontent.com/22065325/91005081-a79c2d80-e5f5-11ea-8d33-fb391b249253.png)

Result from ksql: 0.10.1.1
![image](https://user-images.githubusercontent.com/22065325/91005183-fea20280-e5f5-11ea-9941-e15413faca23.png)

So, I have modified the code a little and now the exception handling is working fine.
![image](https://user-images.githubusercontent.com/22065325/91010928-1df35c80-e603-11ea-8be2-3acb3af0b739.png)
