### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM frolvlad/alpine-python3
-
 WORKDIR /app
-COPY . /app
+COPY *requirements* /app/
 RUN sed -i -e 's/v3\.8/edge/g' /etc/apk/repositories \
     && apk upgrade --update-cache --available \
     && apk add --no-cache librdkafka librdkafka-dev
 RUN apk add --no-cache alpine-sdk python3-dev
 RUN pip install -r requirements.txt
 RUN pip install -r test-requirements.txt
+COPY . /app
 RUN pip install -e .
+


### PR DESCRIPTION
Copying the whole project content with `COPY . /app` before installing the requirements, causes every change in any file to cause reinstallation of all requirements on the next Docker build.  

After the change, only the requirements files are copied first with `COPY *requirements* /app/`   
Then the requirements are installed, and this layer of the image could be cached for later builds, even if the application changes.

It is easy to test and see that after an initial build, changing anything in the application, will not reinstall all the dependencies on the next Docker build, resulting in a much faster build