### PR TITLE
Remove pip unnecessary import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,6 @@
 import os
 
 from setuptools import setup
-from distutils.version import LooseVersion
-import pip
-
-if LooseVersion(pip.__version__) >= "10.0.0":
-    from pip._internal.req import parse_requirements
-else:
-    from pip.req import parse_requirements
 
 def get_install_requirements(path):
     content = open(os.path.join(os.path.dirname(__file__), path)).read()


### PR DESCRIPTION
It seems that the need to use `parse_requirements` disappeared way back in 2017 (see https://github.com/bryanyang0528/ksql-python/commit/2b25445b5ef77f2c48d0916a6f08ec1723841f5f) and as reported in https://github.com/bryanyang0528/ksql-python/issues/117  it is causing errors.