### PR TITLE
Fix StopIteration runtime error from generator for Python > 3.6.x

### DIFF
--- a/ksql/client.py
+++ b/ksql/client.py
@@ -47,13 +47,14 @@ class KSQLAPI(object):
 
     def query(self, query_string, encoding="utf-8", chunk_size=128, stream_properties=None, idle_timeout=None, use_http2=None, return_objects=None):
         if use_http2:
-            yield from self.sa.query2(
+            for result in self.sa.query2(
                 query_string=query_string,
                 encoding=encoding,
                 chunk_size=chunk_size,
                 stream_properties=stream_properties,
                 idle_timeout=idle_timeout,
-            )
+            ):
+                yield result
         else:
             results = self.sa.query(
                 query_string=query_string,
@@ -63,7 +64,8 @@ class KSQLAPI(object):
                 idle_timeout=idle_timeout
             )
 
-            yield from process_query_result(results, return_objects)
+            for query_result in process_query_result(results, return_objects):
+                yield query_result
 
     def close_query(self, query_id):
         return self.sa.close_query(query_id)


### PR DESCRIPTION
Hello,

I've been testing the app and discovered it throws runtime errors during execution of any query when using Python > 3.6.x (with 3.5.x - 3.6.x was working fine):

![image](https://user-images.githubusercontent.com/77639581/211807390-7252b095-6f29-4c9e-9aa0-ce5035d843b1.png)

I fixed the issue by using explicit iteration over subgenerators. 
Now the app works as expected with Python **3.5.x - 3.9.x.**

----------------------
### **Mentions:**

However, I also discovered the app does not work with Python >= 3.10.x because:
> The Iterable abstract class was removed from collections in Python 3.10.x

Which is used by **hyper** here
> from hyper import HTTPConnection

Hyper lib is very old and no longer maintained since 3 years ago.
In order to fix this, I'd suggest refactoring all instances of hyper(HTTPConnection) by using **requests** lib. 
